### PR TITLE
Release 3.3.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
 	<groupId>io.smartdatalake</groupId>
 	<artifactId>spark-extensions_${scala.minor.version}</artifactId>
-	<version>3.3.3</version>
+	<version>3.3.4-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<licenses>

--- a/src/main/scala/org/apache/spark/sql/confluent/avro/AvroSchemaConverter.scala
+++ b/src/main/scala/org/apache/spark/sql/confluent/avro/AvroSchemaConverter.scala
@@ -21,6 +21,7 @@ import org.apache.avro.LogicalTypes.{Date, Decimal, TimestampMicros, TimestampMi
 import org.apache.avro.Schema.Type._
 import org.apache.avro.{LogicalTypes, Schema, SchemaBuilder}
 import org.apache.spark.sql.catalyst.util.RandomUUIDGenerator
+import org.apache.spark.sql.confluent.IncompatibleSchemaException
 import org.apache.spark.sql.types.Decimal.minBytesForPrecision
 import org.apache.spark.sql.types._
 
@@ -193,5 +194,3 @@ object AvroSchemaConverter {
     }
   }
 }
-
-class IncompatibleSchemaException(msg: String, ex: Throwable = null) extends Exception(msg, ex)

--- a/src/main/scala/org/apache/spark/sql/confluent/avro/CatalystDataToConfluentAvro.scala
+++ b/src/main/scala/org/apache/spark/sql/confluent/avro/CatalystDataToConfluentAvro.scala
@@ -6,7 +6,7 @@ import org.apache.avro.io.{BinaryEncoder, EncoderFactory}
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, ExprCode}
 import org.apache.spark.sql.catalyst.expressions.{Expression, UnaryExpression}
-import org.apache.spark.sql.confluent.ConfluentClient
+import org.apache.spark.sql.confluent.{ConfluentClient, IncompatibleSchemaException}
 import org.apache.spark.sql.types.{BinaryType, DataType}
 
 import java.io.ByteArrayOutputStream
@@ -26,6 +26,7 @@ case class CatalystDataToConfluentAvro(child: Expression, subject: String, confl
     val newSchema = new AvroSchema(AvroSchemaConverter.toAvroType(child.dataType, child.nullable))
     val (schemaId, schema) = if (updateAllowed) confluentHelper.setOrUpdateSchema(subject, newSchema, mutualReadCheck)
     else confluentHelper.setOrGetSchema(subject, newSchema)
+    if (!updateAllowed && newSchema != schema) throw new IncompatibleSchemaException(s"New schema for subject $subject is different from existing schema and updateAllowed=false: Existing=$schema New=$newSchema")
     val serializer = new MyAvroSerializer(child.dataType, schema.rawSchema, child.nullable)
     val writer = new GenericDatumWriter[Any](schema.rawSchema)
     SerializerTools(schemaId, serializer, writer)

--- a/src/main/scala/org/apache/spark/sql/confluent/avro/MyAvroSerializer.scala
+++ b/src/main/scala/org/apache/spark/sql/confluent/avro/MyAvroSerializer.scala
@@ -27,6 +27,7 @@ import org.apache.avro.{LogicalTypes, Schema}
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{SpecializedGetters, SpecificInternalRow}
+import org.apache.spark.sql.confluent.IncompatibleSchemaException
 import org.apache.spark.sql.types._
 
 import java.nio.ByteBuffer
@@ -123,7 +124,7 @@ class MyAvroSerializer(rootCatalystType: DataType, rootAvroType: Schema, nullabl
         (getter, ordinal) => new Utf8(getter.getUTF8String(ordinal).getBytes)
 
       case (BinaryType, FIXED) =>
-        val size = avroType.getFixedSize()
+        val size = avroType.getFixedSize
         (getter, ordinal) =>
           val data: Array[Byte] = getter.getBinary(ordinal)
           if (data.length != size) {
@@ -147,7 +148,7 @@ class MyAvroSerializer(rootCatalystType: DataType, rootAvroType: Schema, nullabl
         // output the timestamp value as with millisecond precision.
         case null => (getter, ordinal) => getter.getLong(ordinal) / 1000
         case other => throw new IncompatibleSchemaException(
-          s"Cannot convert Catalyst Timestamp type to Avro logical type ${other}")
+          s"Cannot convert Catalyst Timestamp type to Avro logical type $other")
       }
 
       case (ArrayType(et, containsNull), ARRAY) =>

--- a/src/test/resources/jsonSchema/testJsonSchemaSlim.json
+++ b/src/test/resources/jsonSchema/testJsonSchemaSlim.json
@@ -15,7 +15,8 @@
       "required": [
         "item1",
         "item2"
-      ]
+      ],
+      "additionalProperties": false
     },
     "array": {
       "type": "array",
@@ -28,7 +29,8 @@
           "itemProperty2": {
             "type": "number"
           }
-        }
+        },
+        "additionalProperties": false
       }
     },
     "structure": {
@@ -45,10 +47,12 @@
               "value": {
                 "type": "integer"
               }
-            }
+            },
+            "additionalProperties": false
           }
         }
-      }
+      },
+      "additionalProperties": false
     },
     "integer": {
       "type": "integer"
@@ -80,5 +84,6 @@
     "string",
     "number",
     "boolean"
-  ]
+  ],
+  "additionalProperties": false
 }


### PR DESCRIPTION
Tests showed that schema evolution of Kafka topics didnt work for adding new optional columns. The analysis showed that the schema converters where not specific enough, which is fixed in this release.