### PR TITLE
Remove restrictive avro schema equality test

### DIFF
--- a/src/main/scala/org/apache/spark/sql/confluent/avro/CatalystDataToConfluentAvro.scala
+++ b/src/main/scala/org/apache/spark/sql/confluent/avro/CatalystDataToConfluentAvro.scala
@@ -26,7 +26,6 @@ case class CatalystDataToConfluentAvro(child: Expression, subject: String, confl
     val newSchema = new AvroSchema(AvroSchemaConverter.toAvroType(child.dataType, child.nullable))
     val (schemaId, schema) = if (updateAllowed) confluentHelper.setOrUpdateSchema(subject, newSchema, mutualReadCheck)
     else confluentHelper.setOrGetSchema(subject, newSchema)
-    if (!updateAllowed && newSchema != schema) throw new IncompatibleSchemaException(s"New schema for subject $subject is different from existing schema and updateAllowed=false: Existing=$schema New=$newSchema")
     val serializer = new MyAvroSerializer(child.dataType, schema.rawSchema, child.nullable)
     val writer = new GenericDatumWriter[Any](schema.rawSchema)
     SerializerTools(schemaId, serializer, writer)


### PR DESCRIPTION
I think in the case that `updateAllowed` is false, it is not necessary to check the compatibility between `newSchema` and `schema`. The reason is that `newSchema` is only needed if there is no existing schema. Otherwise, `schema` is used as the target schema for the conversion to avro in `MyAvroSerializer`. If there are any incompatibilities between the dataframe and the avro schema, they will be detected by `MyAvroSerializer`, which will throw an appropriate `IncompatibleSchemaException`.