### PR TITLE
Release 3.2.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
 	<groupId>io.smartdatalake</groupId>
 	<artifactId>spark-extensions_${scala.minor.version}</artifactId>
-	<version>3.2.4</version>
+	<version>3.2.5-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<licenses>

--- a/src/main/scala/org/apache/spark/sql/confluent/avro/CatalystDataToConfluentAvro.scala
+++ b/src/main/scala/org/apache/spark/sql/confluent/avro/CatalystDataToConfluentAvro.scala
@@ -26,7 +26,6 @@ case class CatalystDataToConfluentAvro(child: Expression, subject: String, confl
     val newSchema = new AvroSchema(AvroSchemaConverter.toAvroType(child.dataType, child.nullable))
     val (schemaId, schema) = if (updateAllowed) confluentHelper.setOrUpdateSchema(subject, newSchema, mutualReadCheck)
     else confluentHelper.setOrGetSchema(subject, newSchema)
-    if (!updateAllowed && newSchema != schema) throw new IncompatibleSchemaException(s"New schema for subject $subject is different from existing schema and updateAllowed=false: Existing=$schema New=$newSchema")
     val serializer = new MyAvroSerializer(child.dataType, schema.rawSchema, child.nullable)
     val writer = new GenericDatumWriter[Any](schema.rawSchema)
     SerializerTools(schemaId, serializer, writer)


### PR DESCRIPTION
Removed a schema equality check which was too restrictive because previously compatible dataframes could no longer be converted to Avro.