### PR TITLE
Release 3.4.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
 	<groupId>io.smartdatalake</groupId>
 	<artifactId>spark-extensions_${scala.minor.version}</artifactId>
-	<version>3.4.0</version>
+	<version>3.4.1-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<licenses>


### PR DESCRIPTION
Small but important fix for Spark 3.4: Currently when an SDLB expression is evaluated (e.g. in an expectation or pre/postSql...), case sensitive resolution is enabled in default SQLConf...