### PR TITLE
Use expression-interface to make expression evaluation exchangeable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -403,7 +403,7 @@
 		<dependency>
 			<groupId>ch.zzeekk.spark</groupId>
 			<artifactId>expression-interface_${scala.minor.version}</artifactId>
-			<version>3.5.0-SNAPSHOT</version>
+			<version>3.5.0</version>
 		</dependency>
 
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-gpg-plugin</artifactId>
-						<version>3.0.1</version>
+						<version>3.2.8</version>
 						<executions>
 							<execution>
 								<id>sign-artifacts</id>
@@ -129,7 +129,6 @@
 						<extensions>true</extensions>
 						<configuration>
 							<publishingServerId>central</publishingServerId>
-							<tokenAuth>true</tokenAuth>
 							<autoPublish>false</autoPublish>
 						</configuration>
 					</plugin>
@@ -399,6 +398,12 @@
 			<artifactId>scala-collection-compat_${scala.minor.version}</artifactId>
 			<version>2.11.0</version>
 			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>ch.zzeekk.spark</groupId>
+			<artifactId>expression-interface_${scala.minor.version}</artifactId>
+			<version>3.5.0-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>

--- a/src/main/scala/org/apache/spark/sql/custom/ExpressionEvaluator.scala
+++ b/src/main/scala/org/apache/spark/sql/custom/ExpressionEvaluator.scala
@@ -17,11 +17,12 @@
 
 package org.apache.spark.sql.custom
 
+import ch.zzeekk.spark.expressions.{ExpressionEvaluator => ExpressionEvaluatorIface}
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.analysis.{Analyzer, FakeV2SessionCatalog, FunctionRegistry, Resolver, UnresolvedAttribute, caseSensitiveResolution}
 import org.apache.spark.sql.catalyst.catalog.{CatalogDatabase, ExternalCatalog, InMemoryCatalog, SessionCatalog}
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
-import org.apache.spark.sql.catalyst.expressions.{BindReferences, Expression}
+import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, BindReferences, Expression}
 import org.apache.spark.sql.catalyst.optimizer.{ComputeCurrentTime, ReplaceCurrentLike, ReplaceExpressions, ReplaceUpdateFieldsExpression}
 import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, LogicalPlan, Project}
 import org.apache.spark.sql.catalyst.rules.Rule
@@ -29,16 +30,13 @@ import org.apache.spark.sql.catalyst.types.DataTypeUtils
 import org.apache.spark.sql.catalyst.{CatalystTypeConverters, InternalRow}
 import org.apache.spark.sql.connector.catalog.CatalogManager
 import org.apache.spark.sql.custom.ExpressionEvaluator.{findUnresolvedAttributes, resolveExpression}
-import org.apache.spark.sql.expressions.{UserDefinedAggregator, UserDefinedFunction}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{DataType, StructType}
 import org.apache.spark.sql.{Column, Encoders}
 
-import scala.reflect.ClassTag
 import scala.reflect.runtime.universe._
-import scala.util.{Failure, Success, Try}
-import org.apache.spark.sql.catalyst.expressions.Attribute
-import org.apache.spark.sql.catalyst.plans.logical.LocalRelation
+import scala.reflect.{ClassTag, classTag}
+import scala.util.{Failure, Success}
 
 /**
  * ExpressionEvaluator can evaluate a Spark SQL expression against a case class
@@ -48,7 +46,9 @@ import org.apache.spark.sql.catalyst.plans.logical.LocalRelation
  * @tparam R class of expressions expected return type. This might also be set Any, in that case the result type check is
  *           omitted and complex datatypes will not be mapped to case classes, as they are not specified.
  */
-class ExpressionEvaluator[T<:Product:TypeTag,R:TypeTag](exprCol: Column)(implicit classTagR: ClassTag[R]) {
+class ExpressionEvaluator[T<:Product:TypeTag, R:TypeTag:ClassTag](exprCol: Expression) extends ExpressionEvaluatorIface[T, R] {
+
+  val classTagR: ClassTag[R] = classTag[R]
 
   // prepare evaluator (this is Spark internal API)
   private val dataEncoder = Encoders.product[T].asInstanceOf[ExpressionEncoder[T]]
@@ -151,27 +151,18 @@ object ExpressionEvaluator extends Logging {
    *
    * Note: this code is copied from Spark UDFRegistration.register
    */
-  def registerUdf(name: String, udf: UserDefinedFunction): Unit = {
-    udf match {
-      case udaf: UserDefinedAggregator[_, _, _] =>
-        def builder(children: Seq[Expression]) = udaf.scalaAggregator(children)
-        functionRegistry.createOrReplaceTempFunction(name, builder, "scala_udf")
-      case _ =>
-        def builder(children: Seq[Expression]) = udf.apply(children.map(Column.apply) : _*).expr
-        functionRegistry.createOrReplaceTempFunction(name, builder, "scala_udf")
-    }
+  def registerUdf(name: String, udfBuilder: Seq[Expression] => Expression): Unit = {
+    functionRegistry.createOrReplaceTempFunction(name, udfBuilder, "scala_udf")
   }
 
   /**
    * Resolve an expression against a given schema.
    * A resolved expression has a dataType and can be evaluated against data.
    */
-  def resolveExpression(exprCol: Column, schema: StructType, caseSensitive: Boolean = true): Expression = {
-    val schemaPrep = if (caseSensitive) schema
-    else StructType(schema.map(f => f.copy(name = f.name.toLowerCase)))
-    val attributes = DataTypeUtils.toAttributes(schemaPrep)
+  def resolveExpression(exprCol: Expression, schema: StructType): Expression = {
+    val attributes = DataTypeUtils.toAttributes(schema)
     val localRelation = createLocalRelation(attributes)
-    val rawPlan = Project(Seq(exprCol.alias("test").named),localRelation)
+    val rawPlan = Project(Seq(Alias(exprCol, "exprCol")()), localRelation)
     val resolvedPlan = analyzer.execute(rawPlan)
     val optimizedPlan = optimizerRules.foldLeft(resolvedPlan) {
       case (plan, rule) => rule.apply(plan)

--- a/src/main/scala/org/apache/spark/sql/custom/SparkExpressionEvaluatorFactory.scala
+++ b/src/main/scala/org/apache/spark/sql/custom/SparkExpressionEvaluatorFactory.scala
@@ -1,0 +1,33 @@
+package org.apache.spark.sql.custom
+
+import ch.zzeekk.spark.expressions.ExpressionEvaluatorFactory
+import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.expressions.{SparkUserDefinedFunction, UserDefinedAggregator, UserDefinedFunction}
+import org.apache.spark.sql.functions
+
+import scala.reflect.ClassTag
+import scala.reflect.runtime.universe
+
+
+object SparkExpressionEvaluatorFactory extends ExpressionEvaluatorFactory[Expression] {
+
+  override def getEvaluator[T <: Product : universe.TypeTag, R: universe.TypeTag : ClassTag](expression: String): ExpressionEvaluator[T, R] = {
+    new ExpressionEvaluator[T,R](parseExpression(expression))
+  }
+
+  override def registerUdf(name: String, udfBuilder: Seq[Expression] => Expression): Unit = {
+    ExpressionEvaluator.registerUdf(name, udfBuilder)
+  }
+
+  def parseExpression(sqlText: String): Expression = {
+    functions.expr(sqlText).expr
+  }
+
+  def applyUdf(udf: UserDefinedFunction, exprs: Seq[Expression]): Expression = {
+    udf match {
+      case udf: SparkUserDefinedFunction => udf.createScalaUDF(exprs)
+      case udaf: UserDefinedAggregator[_, _, _] => udaf.scalaAggregator(exprs)
+      case _ => throw new IllegalStateException(s"applyUdf is only implemented for SparkUserDefinedFunction and UserDefinedAggregator, but not for ${getClass.getSimpleName}")
+    }
+  }
+}

--- a/src/main/scala/org/apache/spark/sql/custom/SparkExpressionEvaluatorFactory.scala
+++ b/src/main/scala/org/apache/spark/sql/custom/SparkExpressionEvaluatorFactory.scala
@@ -23,6 +23,10 @@ object SparkExpressionEvaluatorFactory extends ExpressionEvaluatorFactory[Expres
     functions.expr(sqlText).expr
   }
 
+  def registerSparkUdf(name: String, udf: UserDefinedFunction): Unit = {
+    registerUdf(name, exprs => SparkExpressionEvaluatorFactory.applyUdf(udf, exprs))
+  }
+
   def applyUdf(udf: UserDefinedFunction, exprs: Seq[Expression]): Expression = {
     udf match {
       case udf: SparkUserDefinedFunction => udf.createScalaUDF(exprs)

--- a/src/main/scala/org/apache/spark/sql/custom/SparkExpressionEvaluatorFactory.scala
+++ b/src/main/scala/org/apache/spark/sql/custom/SparkExpressionEvaluatorFactory.scala
@@ -4,27 +4,47 @@ import ch.zzeekk.spark.expressions.ExpressionEvaluatorFactory
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.expressions.{SparkUserDefinedFunction, UserDefinedAggregator, UserDefinedFunction}
 import org.apache.spark.sql.functions
+import org.apache.spark.sql.functions.udf
+import org.apache.spark.sql.types.StructType
 
 import scala.reflect.ClassTag
 import scala.reflect.runtime.universe
 
 
-object SparkExpressionEvaluatorFactory extends ExpressionEvaluatorFactory[Expression] {
+object SparkExpressionEvaluatorFactory extends ExpressionEvaluatorFactory {
 
   override def getEvaluator[T <: Product : universe.TypeTag, R: universe.TypeTag : ClassTag](expression: String): ExpressionEvaluator[T, R] = {
-    new ExpressionEvaluator[T,R](parseExpression(expression))
+    new ExpressionEvaluator[T, R](parseExpression(expression))
   }
 
-  override def registerUdf(name: String, udfBuilder: Seq[Expression] => Expression): Unit = {
-    ExpressionEvaluator.registerUdf(name, udfBuilder)
-  }
+  override def registerUdf[RT: universe.TypeTag](name: String, f: () => RT): Unit = ExpressionEvaluator.registerUdf(name, exprs => applyUdf(udf(f), exprs))
+
+  override def registerUdf[RT: universe.TypeTag, A1: universe.TypeTag](name: String, f: A1 => RT): Unit = ExpressionEvaluator.registerUdf(name, exprs => applyUdf(udf(f), exprs))
+
+  override def registerUdf[RT: universe.TypeTag, A1: universe.TypeTag, A2: universe.TypeTag](name: String, f: (A1, A2) => RT): Unit = ExpressionEvaluator.registerUdf(name, exprs => applyUdf(udf(f), exprs))
+
+  override def registerUdf[RT: universe.TypeTag, A1: universe.TypeTag, A2: universe.TypeTag, A3: universe.TypeTag](name: String, f: (A1, A2, A3) => RT): Unit = ExpressionEvaluator.registerUdf(name, exprs => applyUdf(udf(f), exprs))
+
+  override def registerUdf[RT: universe.TypeTag, A1: universe.TypeTag, A2: universe.TypeTag, A3: universe.TypeTag, A4: universe.TypeTag](name: String, f: (A1, A2, A3, A4) => RT): Unit = ExpressionEvaluator.registerUdf(name, exprs => applyUdf(udf(f), exprs))
+
+  override def registerUdf[RT: universe.TypeTag, A1: universe.TypeTag, A2: universe.TypeTag, A3: universe.TypeTag, A4: universe.TypeTag, A5: universe.TypeTag](name: String, f: (A1, A2, A3, A4, A5) => RT): Unit = ExpressionEvaluator.registerUdf(name, exprs => applyUdf(udf(f), exprs))
+
+  override def registerUdf[RT: universe.TypeTag, A1: universe.TypeTag, A2: universe.TypeTag, A3: universe.TypeTag, A4: universe.TypeTag, A5: universe.TypeTag, A6: universe.TypeTag](name: String, f: (A1, A2, A3, A4, A5, A6) => RT): Unit = ExpressionEvaluator.registerUdf(name, exprs => applyUdf(udf(f), exprs))
+
+  override def registerUdf[RT: universe.TypeTag, A1: universe.TypeTag, A2: universe.TypeTag, A3: universe.TypeTag, A4: universe.TypeTag, A5: universe.TypeTag, A6: universe.TypeTag, A7: universe.TypeTag](name: String, f: (A1, A2, A3, A4, A5, A6, A7) => RT): Unit = ExpressionEvaluator.registerUdf(name, exprs => applyUdf(udf(f), exprs))
+
+  override def registerUdf[RT: universe.TypeTag, A1: universe.TypeTag, A2: universe.TypeTag, A3: universe.TypeTag, A4: universe.TypeTag, A5: universe.TypeTag, A6: universe.TypeTag, A7: universe.TypeTag, A8: universe.TypeTag](name: String, f: (A1, A2, A3, A4, A5, A6, A7, A8) => RT): Unit = ExpressionEvaluator.registerUdf(name, exprs => applyUdf(udf(f), exprs))
+
+  override def registerUdf[RT: universe.TypeTag, A1: universe.TypeTag, A2: universe.TypeTag, A3: universe.TypeTag, A4: universe.TypeTag, A5: universe.TypeTag, A6: universe.TypeTag, A7: universe.TypeTag, A8: universe.TypeTag, A9: universe.TypeTag](name: String, f: (A1, A2, A3, A4, A5, A6, A7, A8, A9) => RT): Unit = ExpressionEvaluator.registerUdf(name, exprs => applyUdf(udf(f), exprs))
+
+  override def registerUdf[RT: universe.TypeTag, A1: universe.TypeTag, A2: universe.TypeTag, A3: universe.TypeTag, A4: universe.TypeTag, A5: universe.TypeTag, A6: universe.TypeTag, A7: universe.TypeTag, A8: universe.TypeTag, A9: universe.TypeTag, A10: universe.TypeTag](name: String, f: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10) => RT): Unit = ExpressionEvaluator.registerUdf(name, exprs => applyUdf(udf(f), exprs))
 
   def parseExpression(sqlText: String): Expression = {
     functions.expr(sqlText).expr
   }
 
-  def registerSparkUdf(name: String, udf: UserDefinedFunction): Unit = {
-    registerUdf(name, exprs => SparkExpressionEvaluatorFactory.applyUdf(udf, exprs))
+  def resolveExpression(exprCol: Expression, schema: StructType): Expression = {
+    ExpressionEvaluator.resolveExpression(exprCol, schema)
   }
 
   def applyUdf(udf: UserDefinedFunction, exprs: Seq[Expression]): Expression = {

--- a/src/test/scala/org/apache/spark/sql/custom/ExpressionEvaluatorTest.scala
+++ b/src/test/scala/org/apache/spark/sql/custom/ExpressionEvaluatorTest.scala
@@ -18,7 +18,6 @@
 package org.apache.spark.sql.custom
 
 import org.apache.spark.sql.custom.SparkExpressionEvaluatorFactory.parseExpression
-import org.apache.spark.sql.functions._
 import org.scalatest.funsuite.AnyFunSuite
 
 import java.sql.Timestamp
@@ -91,8 +90,8 @@ class ExpressionEvaluatorTest extends AnyFunSuite {
   }
 
   test("evaluate expression with user defined function") {
-    val udfFirstElementY = udf((entries: Seq[Entry]) => entries.map(_.y).head)
-    SparkExpressionEvaluatorFactory.registerSparkUdf("get_first_element", udfFirstElementY)
+    val funcFirstElementY = (entries: Seq[Entry]) => entries.map(_.y).head
+    SparkExpressionEvaluatorFactory.registerUdf("get_first_element", funcFirstElementY)
     val expression = "get_first_element(s)"
     val evaluator = SparkExpressionEvaluatorFactory.getEvaluator[TestObj,String](expression)
     val result = evaluator.apply(input)

--- a/src/test/scala/org/apache/spark/sql/custom/ExpressionEvaluatorTest.scala
+++ b/src/test/scala/org/apache/spark/sql/custom/ExpressionEvaluatorTest.scala
@@ -18,7 +18,6 @@
 package org.apache.spark.sql.custom
 
 import org.apache.spark.sql.custom.SparkExpressionEvaluatorFactory.parseExpression
-import org.apache.spark.sql.expressions.UserDefinedFunction
 import org.apache.spark.sql.functions._
 import org.scalatest.funsuite.AnyFunSuite
 
@@ -91,20 +90,14 @@ class ExpressionEvaluatorTest extends AnyFunSuite {
     assert(result == Timestamp.valueOf(LocalDate.of(2016,4,8).atStartOfDay()))
   }
 
-
   test("evaluate expression with user defined function") {
     val udfFirstElementY = udf((entries: Seq[Entry]) => entries.map(_.y).head)
-    registerUdf("get_first_element", udfFirstElementY)
+    SparkExpressionEvaluatorFactory.registerSparkUdf("get_first_element", udfFirstElementY)
     val expression = "get_first_element(s)"
     val evaluator = SparkExpressionEvaluatorFactory.getEvaluator[TestObj,String](expression)
     val result = evaluator.apply(input)
     assert(result == "test0")
   }
-
-  def registerUdf(name: String, udf: UserDefinedFunction): Unit = {
-    SparkExpressionEvaluatorFactory.registerUdf(name, exprs => SparkExpressionEvaluatorFactory.applyUdf(udf, exprs))
-  }
-
 }
 
 case class Entry(y: String, z: Int)

--- a/src/test/scala/org/apache/spark/sql/custom/ExpressionEvaluatorTest.scala
+++ b/src/test/scala/org/apache/spark/sql/custom/ExpressionEvaluatorTest.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.custom
 
+import org.apache.spark.sql.custom.SparkExpressionEvaluatorFactory.parseExpression
+import org.apache.spark.sql.expressions.UserDefinedFunction
 import org.apache.spark.sql.functions._
 import org.scalatest.funsuite.AnyFunSuite
 
@@ -34,48 +36,48 @@ class ExpressionEvaluatorTest extends AnyFunSuite {
 
   test("evaluate expression with functions") {
     val expression = "concat(b, '-', cast(a * 2 as int))"
-    val evaluator = new ExpressionEvaluator[TestObj,String](expr(expression))
+    val evaluator = new ExpressionEvaluator[TestObj,String](parseExpression(expression))
     val result = evaluator.apply(input)
     assert(result == "ok-3")
   }
 
   test("evaluate expression with functions on list") {
     val expression = "array_max(transform( s, entry -> entry.z ))"
-    val evaluator = new ExpressionEvaluator[TestObj,Int](expr(expression))
+    val evaluator = new ExpressionEvaluator[TestObj,Int](parseExpression(expression))
     val result = evaluator.apply(input)
     assert(result == 1)
   }
 
   test("evaluate expression on map") {
     val expression = "m['test2'].z + m['test3'].z"
-    val evaluator = new ExpressionEvaluator[TestObj,Int](expr(expression))
+    val evaluator = new ExpressionEvaluator[TestObj,Int](parseExpression(expression))
     val result = evaluator.apply(input)
     assert(result == 5)
   }
 
   test("evaluate expression returning complex type") {
     val expression = "m"
-    val evaluator = new ExpressionEvaluator[TestObj,Map[String,Entry]](expr(expression))
+    val evaluator = new ExpressionEvaluator[TestObj,Map[String,Entry]](parseExpression(expression))
     val result = evaluator.apply(input)
     assert(result.values.toSeq.head.z == 2)
   }
 
   test("evaluate expression with type any") {
     val expression = "a"
-    val evaluator = new ExpressionEvaluator[TestObj,Any](expr(expression))
+    val evaluator = new ExpressionEvaluator[TestObj,Any](parseExpression(expression))
     val result = evaluator.apply(input)
     assert(result == 1.5f)
   }
 
   test("evaluate expression: exception with unknown attribute contains its name") {
     val expression = "concat(s[0].y, b, abc)"
-    val ex = intercept[Exception](new ExpressionEvaluator[TestObj,Any](expr(expression)))
+    val ex = intercept[Exception](new ExpressionEvaluator[TestObj,Any](parseExpression(expression)))
     assert(ex.getMessage.contains("abc"))
   }
 
   test("evaluate expression: evaluation is case sensitive") {
     val expression = "concat(s[0].Y, b)"
-    val ex = intercept[Exception](new ExpressionEvaluator[TestObj, Any](expr(expression)))
+    val ex = intercept[Exception](new ExpressionEvaluator[TestObj, Any](parseExpression(expression)))
     assert(ex.getMessage.contains("Y"))
   }
 
@@ -84,11 +86,24 @@ class ExpressionEvaluatorTest extends AnyFunSuite {
     // see also https://jaceklaskowski.gitbooks.io/mastering-spark-sql/content/spark-sql-Expression-RuntimeReplaceable.html
     // and https://jaceklaskowski.gitbooks.io/mastering-spark-sql/content/spark-sql-Optimizer-ReplaceExpressions.html
     val expression = "to_date('2016-04-08', 'yyyy-MM-dd')"
-    val evaluator = new ExpressionEvaluator[TestObj,Any](expr(expression))
+    val evaluator = new ExpressionEvaluator[TestObj,Any](parseExpression(expression))
     val result = evaluator.apply(input)
     assert(result == Timestamp.valueOf(LocalDate.of(2016,4,8).atStartOfDay()))
   }
 
+
+  test("evaluate expression with user defined function") {
+    val udfFirstElementY = udf((entries: Seq[Entry]) => entries.map(_.y).head)
+    registerUdf("get_first_element", udfFirstElementY)
+    val expression = "get_first_element(s)"
+    val evaluator = SparkExpressionEvaluatorFactory.getEvaluator[TestObj,String](expression)
+    val result = evaluator.apply(input)
+    assert(result == "test0")
+  }
+
+  def registerUdf(name: String, udf: UserDefinedFunction): Unit = {
+    SparkExpressionEvaluatorFactory.registerUdf(name, exprs => SparkExpressionEvaluatorFactory.applyUdf(udf, exprs))
+  }
 
 }
 


### PR DESCRIPTION
This is to prepare for Spark Connect compatibility: https://github.com/smart-data-lake/smart-data-lake/issues/953